### PR TITLE
fixed ruby path on standard linux install

### DIFF
--- a/listen
+++ b/listen
@@ -1,4 +1,4 @@
-#!/bin/env ruby
+#!/usr/bin/env ruby
 
 require 'pp'
 require 'json'


### PR DESCRIPTION
this change is required to run the listen script on standard Linux installs otherwise you may get error like:
$ ./listen -p 5000
bash: ./listen: /bin/env: bad interpreter: No such file or directory

With the ruby path in listen is consistent with vson.

